### PR TITLE
Fixing minor error in tutorial docs

### DIFF
--- a/EXERCISE-2.md
+++ b/EXERCISE-2.md
@@ -182,7 +182,7 @@ bash-4.4# proto_generator \
 
 You will find `openconfig.proto` and `enums.proto` in the `/proto/openconfig` directory.
 
-*Extra Credit:* Try to find the Protobuf message fiels used to enable a port or
+*Extra Credit:* Try to find the Protobuf message fields used to enable a port or
 get the ingress packets counter in the protobuf messages.
 
 *Hint:* Searching by schemapath might help.
@@ -300,10 +300,11 @@ configuration port between `leaf1` and `h1a`:
 
 ```
 $ util/gnmi-cli --grpc-addr localhost:50001 get \
-    /interfaces/interface[name=leaf1-eth3]/config/enabled
+    /interfaces/interface[name=leaf1-eth3]/config
 ```
 
-You should see this response:
+You should see this response containing 2 leafs under config - **enabled** and
+**health-indicator**:
 
 ```
 RESPONSE

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -41,8 +41,7 @@
         <onos.app.requires>
             org.onosproject.drivers.bmv2,
             org.onosproject.lldpprovider,
-            org.onosproject.hostprovider,
-            org.onosproject.gui
+            org.onosproject.hostprovider
         </onos.app.requires>
     </properties>
 


### PR DESCRIPTION
Minor documentation errors
1) In topo.png the mac address of leaf2 was wrong (also in the slides but I can't fix that)
2) In EXERCISE2.md the result shows both enabled and health-indicator so changed the request
3) In app/pom.xml remove gui as this is already in the makefile and it precludes disabling the legacy gui and using gui2 (if one wanted to).