### PR TITLE
Change ip neigh command to use replace instead of add

### DIFF
--- a/EXERCISE-1.md
+++ b/EXERCISE-1.md
@@ -298,17 +298,17 @@ be able to handle NDP packets if correctly programmed using P4Runtime (see
 `l2_ternary_table`), however, **to keep things simple for now, let's insert two
 static NDP entries in our hosts.**
 
-Add and NDP entry to `h1a`, mapping `h1b`'s IPv6 address (`2001:1:1::b`) to its
-MAC addres (`00:00:00:00:00:1B`):
+Add an NDP entry to `h1a`, mapping `h1b`'s IPv6 address (`2001:1:1::b`) to its
+MAC address (`00:00:00:00:00:1B`):
 
 ```
-mininet> h1a ip -6 neigh add 2001:1:1::B lladdr 00:00:00:00:00:1B dev h1a-eth0
+mininet> h1a ip -6 neigh replace 2001:1:1::B lladdr 00:00:00:00:00:1B dev h1a-eth0
 ```
 
-And vice versa, add and NDP entry to `h1b` to resolve `h1a`'s address:
+And vice versa, add an NDP entry to `h1b` to resolve `h1a`'s address:
 
 ```
-mininet> h1b ip -6 neigh add 2001:1:1::A lladdr 00:00:00:00:00:1A dev h1b-eth0
+mininet> h1b ip -6 neigh replace 2001:1:1::A lladdr 00:00:00:00:00:1A dev h1b-eth0
 ```
 
 ### Start ping


### PR DESCRIPTION
Pinging between h1a and h1b before the permanent neighbor entries are added results in a FAILED neighbor entry. This entry is not overwritten by "ip neigh add", resulting in the tutorial failing. Use "ip neigh replace" instead, which is safe for both no entries or a failed entry in the neighbor table.