### PR TITLE
Do not depend on locally built Docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-include util/docker/Makefile.vars
-
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 curr_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
+
+include util/docker/Makefile.vars
 
 onos_url := http://localhost:8181/onos
 onos_curl := curl --fail -sSL --user onos:rocks --noproxy localhost

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,8 @@
-ONOS_IMG := onosproject/onos:2.2.0
-P4RT_SH_IMG := p4lang/p4runtime-sh:latest
-P4C_IMG := opennetworking/p4c:stable
-MN_STRATUM_IMG := opennetworking/mn-stratum:latest
-MAVEN_IMG := maven:3.6.1-jdk-11-slim
-PTF_IMG := ngsdn-tutorial-ptf
-GNMI_CLI_IMG := bocon/gnmi-cli:latest
-YANG_IMG := bocon/yang-tools:latest
-
-ONOS_SHA := sha256:c1d18e6957a785d0234855eb8c70909bfc68849338f0567e12a6ae7ce6f4ba91
-P4RT_SH_SHA := sha256:6ae50afb5bde620acb9473ce6cd7b990ff6cc63fe4113cf5584c8e38fe42176c
-P4C_SHA := sha256:8f9d27a6edf446c3801db621359fec5de993ebdebc6844d8b1292e369be5dfea
-MN_STRATUM_SHA := sha256:ae7c59885509ece8062e196e6a8fb6aa06386ba25df646ed27c765d92d131692
-MAVEN_SHA := sha256:ca67b12d638fe1b8492fa4633200b83b118f2db915c1f75baf3b0d2ef32d7263
-GNMI_CLI_SHA := sha256:6f1590c35e71c07406539d0e1e288e87e1e520ef58de25293441c3b9c81dffc0
-YANG_SHA := sha256:feb2dc322af113fc52f17b5735454abfbe017972c867e522ba53ea44e8386fd2
+include util/docker/Makefile.vars
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 curr_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
-curr_dir_sha := $(shell echo -n "$(curr_dir)" | shasum | cut -c1-7)
 
-app_build_container_name := app-build-${curr_dir_sha}
 onos_url := http://localhost:8181/onos
 onos_curl := curl --fail -sSL --user onos:rocks --noproxy localhost
 app_name := org.onosproject.ngsdn-tutorial
@@ -38,19 +21,16 @@ _docker_pull_all:
 	docker tag ${P4C_IMG}@${P4C_SHA} ${P4C_IMG}
 	docker pull ${MN_STRATUM_IMG}@${MN_STRATUM_SHA}
 	docker tag ${MN_STRATUM_IMG}@${MN_STRATUM_SHA} ${MN_STRATUM_IMG}
-	docker pull ${MAVEN_IMG}@${MAVEN_SHA}
-	docker tag ${MAVEN_IMG}@${MAVEN_SHA} ${MAVEN_IMG}
+	docker pull ${MVN_IMG}@${MVN_SHA}
+	docker tag ${MVN_IMG}@${MVN_SHA} ${MVN_IMG}
+	docker pull ${PTF_IMG}@${PTF_SHA}
+	docker tag ${PTF_IMG}@${PTF_SHA} ${PTF_IMG}
 	docker pull ${GNMI_CLI_IMG}@${GNMI_CLI_SHA}
 	docker tag ${GNMI_CLI_IMG}@${GNMI_CLI_SHA} ${GNMI_CLI_IMG}
 	docker pull ${YANG_IMG}@${YANG_SHA}
 	docker tag ${YANG_IMG}@${YANG_SHA} ${YANG_IMG}
 
-_docker_build:
-	cd util/docker/ptf && docker build -t ${PTF_IMG} .
-
-# Pull/build Docker images and build app to seed mvn repo inside container, i.e.
-# download deps
-deps: _docker_pull_all _docker_build _create_mvn_container _mvn_package
+deps: _docker_pull_all
 
 start:
 	@mkdir -p tmp/onos
@@ -95,9 +75,6 @@ clean:
 	-$(NGSDN_TUTORIAL_SUDO) rm -rf app/src/main/resources/bmv2.json
 	-$(NGSDN_TUTORIAL_SUDO) rm -rf app/src/main/resources/p4info.txt
 
-deep-clean: clean
-	-docker container rm ${app_build_container_name}
-
 p4-build: p4src/main.p4
 	$(info *** Building P4 program...)
 	@mkdir -p p4src/build
@@ -108,13 +85,7 @@ p4-build: p4src/main.p4
 	@echo "*** P4 program compiled successfully! Output files are in p4src/build"
 
 p4-test:
-	@cd ptf && ./run_tests $(TEST)
-
-# Create container once, use it many times to preserve mvn repo cache.
-_create_mvn_container:
-	@if ! docker container ls -a --format '{{.Names}}' | grep -q ${app_build_container_name} ; then \
-		docker create -v ${curr_dir}/app:/mvn-src -w /mvn-src --name ${app_build_container_name} ${MAVEN_IMG} mvn clean package; \
-	fi
+	@cd ptf && PTF_DOCKER_IMG=$(PTF_IMG) ./run_tests $(TEST)
 
 _copy_p4c_out:
 	$(info *** Copying p4c outputs to app resources...)
@@ -125,9 +96,9 @@ _copy_p4c_out:
 _mvn_package:
 	$(info *** Building ONOS app...)
 	@mkdir -p app/target
-	@docker start -a -i ${app_build_container_name}
+	@docker run --rm -v ${curr_dir}/app:/mvn-src -w /mvn-src ${MVN_IMG} mvn -o clean package
 
-app-build: p4-build _copy_p4c_out _create_mvn_container _mvn_package
+app-build: p4-build _copy_p4c_out _mvn_package
 	$(info *** ONOS app .oar package created succesfully)
 	@ls -1 app/target/*.oar
 

--- a/ptf/run_tests
+++ b/ptf/run_tests
@@ -5,7 +5,7 @@ set -e
 PTF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 P4SRC_DIR=${PTF_DIR}/../p4src
 P4C_OUT=${P4SRC_DIR}/build
-DOCKER_IMG=ngsdn-tutorial-ptf
+PTF_DOCKER_IMG=${PTF_DOCKER_IMG:-undefined}
 
 runName=ptf-${RANDOM}
 
@@ -21,7 +21,7 @@ echo "*** Starting stratum_bmv2 in Docker (${runName})..."
 docker run --name "${runName}" -d --privileged --rm \
     -v "${PTF_DIR}":/ptf -w /ptf \
     -v "${P4C_OUT}":/p4c-out \
-    "${DOCKER_IMG}" \
+    "${PTF_DOCKER_IMG}" \
     ./lib/start_bmv2.sh > /dev/null
 
 sleep 2

--- a/util/docker/Makefile
+++ b/util/docker/Makefile
@@ -1,0 +1,20 @@
+include Makefile.vars
+
+build: build-ptf build-mvn
+push: push-ptf push-mvn
+
+build-ptf:
+	cd ptf && docker build --build-arg MN_STRATUM_SHA=$(MN_STRATUM_SHA) \
+		-t ${PTF_IMG} .
+
+build-mvn:
+	cd ../../app && docker build --squash -f ../util/docker/mvn/Dockerfile \
+		-t ${MVN_IMG} .
+
+push-ptf:
+	# Remember to update Makefile.vars with the new image sha
+	docker push ${PTF_IMG}
+
+push-mvn:
+	# Remember to update Makefile.vars with the new image sha
+	docker push ${MVN_IMG}

--- a/util/docker/Makefile.vars
+++ b/util/docker/Makefile.vars
@@ -1,0 +1,17 @@
+ONOS_IMG := onosproject/onos:2.2.0
+P4RT_SH_IMG := p4lang/p4runtime-sh:latest
+P4C_IMG := opennetworking/p4c:stable
+MN_STRATUM_IMG := opennetworking/mn-stratum:latest
+MVN_IMG := ccasconeonf/ngsdn-tutorial:mvn
+PTF_IMG := ccasconeonf/ngsdn-tutorial:ptf
+GNMI_CLI_IMG := bocon/gnmi-cli:latest
+YANG_IMG := bocon/yang-tools:latest
+
+ONOS_SHA := sha256:c1d18e6957a785d0234855eb8c70909bfc68849338f0567e12a6ae7ce6f4ba91
+P4RT_SH_SHA := sha256:6ae50afb5bde620acb9473ce6cd7b990ff6cc63fe4113cf5584c8e38fe42176c
+P4C_SHA := sha256:8f9d27a6edf446c3801db621359fec5de993ebdebc6844d8b1292e369be5dfea
+MN_STRATUM_SHA := sha256:ae7c59885509ece8062e196e6a8fb6aa06386ba25df646ed27c765d92d131692
+PTF_SHA := sha256:77ea53bf5d17c0ab984103919da9b7effd322031dadb943fcc108f9dc9607097
+MVN_SHA := sha256:be12d38e25c7ecb826040cea09c9c1bbb08cd230306580e53d84a1f88ae7eeb1
+GNMI_CLI_SHA := sha256:6f1590c35e71c07406539d0e1e288e87e1e520ef58de25293441c3b9c81dffc0
+YANG_SHA := sha256:feb2dc322af113fc52f17b5735454abfbe017972c867e522ba53ea44e8386fd2

--- a/util/docker/mvn/Dockerfile
+++ b/util/docker/mvn/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019-present Open Networking Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Docker image to build the ONOS app.
+# Provides pre-poulated maven repo cache to allow offline builds.
+
+FROM maven:3.6.1-jdk-11-slim
+
+COPY . /mvn-src
+WORKDIR /mvn-src
+
+RUN mvn clean package && rm -rf ./*

--- a/util/docker/ptf/Dockerfile
+++ b/util/docker/ptf/Dockerfile
@@ -14,6 +14,8 @@
 
 # Docker image to run PTF-based data plane tests using stratum_bmv2
 
+ARG MN_STRATUM_SHA
+
 FROM bitnami/minideb:stretch as builder
 
 ENV BUILD_DEPS \
@@ -31,7 +33,7 @@ ENV PIP_DEPS \
     ipaddress
 RUN pip install --no-cache-dir --root /output $PIP_DEPS
 
-FROM opennetworking/mn-stratum:latest as runtime
+FROM opennetworking/mn-stratum:latest@$MN_STRATUM_SHA as runtime
 
 LABEL description="Docker image to run PTF-based data plane tests using stratum_bmv2"
 


### PR DESCRIPTION
But pull everything from Docker Hub. This patch is a workaround to the
issue seen in the ONF Tutorial Cloud, where download bandwidth for the
init container is extremely low when executing commands inside
containers that access the Internet (e.g., to pull Maven dependencies or
Python packages).