### PR TITLE
Enabled --help for p4rt-sh

### DIFF
--- a/util/p4rt-sh
+++ b/util/p4rt-sh
@@ -46,7 +46,7 @@ def main():
             raise argparse.ArgumentError(
                 "Invalid pipeline config, expected <p4info path>,<binary config path>")
 
-    parser = argparse.ArgumentParser(description='P4Runtime shell docker wrapper', add_help=False)
+    parser = argparse.ArgumentParser(description='P4Runtime shell docker wrapper', add_help=True)
     parser.add_argument('--grpc-addr',
                         help='P4Runtime gRPC server address',
                         metavar='<host>:<port>',


### PR DESCRIPTION
In exercise 1, there's an instruction saying that
> For a list of arguments you can type util/p4rt-sh --help

But --help doesn't actually work without this patch.